### PR TITLE
PF-103 Handle multiple jobs per fork

### DIFF
--- a/lib/resque/plugins/round_robin/version.rb
+++ b/lib/resque/plugins/round_robin/version.rb
@@ -1,7 +1,7 @@
 module Resque
   module Plugins
     module RoundRobin
-      VERSION = "1.0.0"
+      VERSION = "1.0.1"
     end
   end
 end


### PR DESCRIPTION
Improve the efficiency of resque by handling multiple jobs per fork.

This is only applied to the webhook queues where we process multiple jobs from the same account - so there are no cross-account issues.

Pass `JOBS_PER_FORK` in environment to run more than one job per fork.