### PR TITLE
A-13637 Round robin the dynamic queues in priority order

### DIFF
--- a/lib/resque/plugins/round_robin/round_robin.rb
+++ b/lib/resque/plugins/round_robin/round_robin.rb
@@ -17,12 +17,15 @@ module Resque::Plugins
     end
 
     def rotated_queues
+      @priority_order ||= @queues.map.with_index {|q, i| [q.chomp("*"), i] }.to_h
       @n ||= 0
       @n += 1
       rot_queues = queues # since we rely on the resque-dynamic-queues plugin, this is all the queues, expanded out
       if rot_queues.size > 0
         @n = @n % rot_queues.size
-        rot_queues.rotate(@n)
+        rot_queues.rotate(@n).sort_by do |queue|
+          @priority_order[queue.sub(/\d+$/, '')] || @priority_order.size
+        end
       else
         rot_queues
       end
@@ -33,7 +36,7 @@ module Resque::Plugins
       # find the queuename, count it.
       busy_queues.select {|q| q == queuename }.size
     end
-    
+
     def queue_empty?(queuename)
       Resque.data_store.queue_size(queuename) == 0
     end
@@ -57,7 +60,7 @@ module Resque::Plugins
         Resque.data_store.remove_queue(queuename)
         return false
       end
-      
+
       cur_depth = queue_depth(queuename)
       max = max_qeueue_workers_for(queuename)
       return true if max == 0 # 0 means no limiting

--- a/lib/resque/plugins/round_robin/round_robin.rb
+++ b/lib/resque/plugins/round_robin/round_robin.rb
@@ -24,7 +24,7 @@ module Resque::Plugins
       if rot_queues.size > 0
         @n = @n % rot_queues.size
         rot_queues.rotate(@n).sort_by do |queue|
-          @priority_order[queue.sub(/\d+$/, '')] || @priority_order.size
+          @priority_order.find { |k, v| queue.start_with?(k) }&.last || @priority_order.size
         end
       else
         rot_queues

--- a/spec/redis-test.conf
+++ b/spec/redis-test.conf
@@ -82,9 +82,9 @@ dbfilename dump.rdb
 #
 # The DB will be written inside this directory, with the filename specified
 # above using the 'dbfilename' configuration directive.
-# 
+#
 # Also the Append Only File will be created inside this directory.
-# 
+#
 # Note that you must specify a directory here, not a file name.
 dir .
 
@@ -112,7 +112,7 @@ dir .
 #
 # This should stay commented out for backward compatibility and because most
 # people do not need auth (e.g. they run their own servers).
-# 
+#
 # Warning: since Redis is pretty fast an outside user can try up to
 # 150k passwords per second against a good box. This means that you should
 # use a very strong password otherwise it will be very easy to break.
@@ -172,7 +172,7 @@ appendonly no
 # appendfilename appendonly.aof
 
 # The fsync() call tells the Operating System to actually write data on disk
-# instead to wait for more data in the output buffer. Some OS will really flush 
+# instead to wait for more data in the output buffer. Some OS will really flush
 # data on disk, some other OS will just try to do it ASAP.
 #
 # Redis supports three different modes:
@@ -206,7 +206,7 @@ appendfsync everysec
 # To enable VM just set 'vm-enabled' to yes, and set the following three
 # VM parameters accordingly to your needs.
 
-vm-enabled no
+# vm-enabled no
 # vm-enabled yes
 
 # This is the path of the Redis swap file. As you can guess, swap files
@@ -214,13 +214,13 @@ vm-enabled no
 # file for every redis process you are running. Redis will complain if the
 # swap file is already in use.
 #
-# The best kind of storage for the Redis swap file (that's accessed at random) 
+# The best kind of storage for the Redis swap file (that's accessed at random)
 # is a Solid State Disk (SSD).
 #
 # *** WARNING *** if you are using a shared hosting the default of putting
 # the swap file under /tmp is not secure. Create a dir with access granted
 # only to Redis user and configure Redis to create the swap file there.
-vm-swap-file ./tmp/redis.swap
+# vm-swap-file ./tmp/redis.swap
 
 # vm-max-memory configures the VM to use at max the specified amount of
 # RAM. Everything that deos not fit will be swapped on disk *if* possible, that
@@ -230,7 +230,7 @@ vm-swap-file ./tmp/redis.swap
 # default, just specify the max amount of RAM you can in bytes, but it's
 # better to leave some margin. For instance specify an amount of RAM
 # that's more or less between 60 and 80% of your free RAM.
-vm-max-memory 0
+#vm-max-memory 0
 
 # Redis swap files is split into pages. An object can be saved using multiple
 # contiguous pages, but pages can't be shared between different objects.
@@ -241,7 +241,7 @@ vm-max-memory 0
 # If you use a lot of small objects, use a page size of 64 or 32 bytes.
 # If you use a lot of big objects, use a bigger page size.
 # If unsure, use the default :)
-vm-page-size 32
+# vm-page-size 32
 
 # Number of total memory pages in the swap file.
 # Given that the page table (a bitmap of free/used pages) is taken in memory,
@@ -254,7 +254,7 @@ vm-page-size 32
 #
 # It's better to use the smallest acceptable value for your application,
 # but the default is large in order to work in most conditions.
-vm-pages 134217728
+#vm-pages 134217728
 
 # Max number of VM I/O threads running at the same time.
 # This threads are used to read/write data from/to swap file, since they
@@ -265,21 +265,21 @@ vm-pages 134217728
 #
 # The special value of 0 turn off threaded I/O and enables the blocking
 # Virtual Memory implementation.
-vm-max-threads 4
+# vm-max-threads 4
 
 ############################### ADVANCED CONFIG ###############################
 
 # Glue small output buffers together in order to send small replies in a
 # single TCP packet. Uses a bit more CPU but most of the times it is a win
 # in terms of number of queries per second. Use 'yes' if unsure.
-glueoutputbuf yes
+# glueoutputbuf yes
 
 # Hashes are encoded in a special way (much more memory efficient) when they
 # have at max a given numer of elements, and the biggest element does not
 # exceed a given threshold. You can configure this limits with the following
 # configuration directives.
-hash-max-zipmap-entries 64
-hash-max-zipmap-value 512
+# hash-max-zipmap-entries 64
+# hash-max-zipmap-value 512
 
 # Active rehashing uses 1 millisecond every 100 milliseconds of CPU time in
 # order to help rehashing the main Redis hash table (the one mapping top-level
@@ -288,7 +288,7 @@ hash-max-zipmap-value 512
 # that is rhashing, the more rehashing "steps" are performed, so if the
 # server is idle the rehashing is never complete and some more memory is used
 # by the hash table.
-# 
+#
 # The default is to use this millisecond 10 times every second in order to
 # active rehashing the main dictionaries, freeing memory when possible.
 #

--- a/spec/round-robin_spec.rb
+++ b/spec/round-robin_spec.rb
@@ -4,22 +4,35 @@ describe "RoundRobin" do
 
   before(:each) do
     Resque.redis.flushall
+    stub_const("ENV", { "QUEUES" => "q_*,r_*" })
   end
 
   context "a worker" do
     it "switches queues, round robin" do
-      5.times { Resque::Job.create(:q1, SomeJob) }
-      5.times { Resque::Job.create(:q2, SomeJob) }
+      5.times { Resque::Job.create(:r_1, SomeJob) }
+      5.times { Resque::Job.create(:q_1, SomeJob) }
+      5.times { Resque::Job.create(:q_2, SomeJob) }
 
-      worker = Resque::Worker.new(:q1, :q2)
-
-      worker.process
-      Resque.size(:q1).should == 5
-      Resque.size(:q2).should == 4
+      worker = Resque::Worker.new
 
       worker.process
-      Resque.size(:q1).should == 4
-      Resque.size(:q2).should == 4
+      Resque.size(:q_1).should == 5
+      Resque.size(:q_2).should == 4
+      Resque.size(:r_1).should == 5
+
+      worker.process
+      Resque.size(:q_1).should == 4
+      Resque.size(:q_2).should == 4
+      Resque.size(:r_1).should == 5
+
+      8.times do
+        worker.process
+      end
+      Resque.size(:q_1).should == 0
+      Resque.size(:q_2).should == 0
+      Resque.size(:r_1).should == 5
+      worker.process
+      Resque.size(:r_1).should == 4
     end
 
     it 'skips a queue that is being processed by another worker'
@@ -28,5 +41,5 @@ describe "RoundRobin" do
   it "should pass lint" do
     Resque::Plugin.lint(Resque::Plugins::RoundRobin)
   end
-  
+
 end


### PR DESCRIPTION
## Description 

[Aha! Feature](https://big.aha.io/develop/features/A-13637)

Typically in resque, when we start workers, we do something like
`QUEUE=a,b bundle exec rake resque:work` 
This will setup priority queues so that the `a` queue is prioritized over the `b` queue. 

With the round-robin queing, we can setup some dynamic queues like
`QUEUE=a_*,b_* bundle exec rake resque:account_work` 

However, it will have the all at equal priority. So even if there are jobs in the `a_*` queue, depending on the rotation, it may prioritize the `b_*` jobs before hand. 

With our setup, we are noticing that there are times when the `integration_exports_*` queue stops picking up jobs for a while. 

Here is some [logs](https://secure.aha.io/admin/aha_log_viewer/queries/7112202383674592685?display_time_zone=UTC) for example
<img width="1214" alt="image" src="https://user-images.githubusercontent.com/1671796/175364002-c75212c2-72de-4901-a46a-0e183a4abc7e.png">
We can see that there are times when we are enqueueing jobs, but they don't get processed for a while. It was too big for a screenshot, but you can see in the logs that there are jobs that start being enqueued at `2022-06-21 15:53:43.819` and it isn't until `2022-06-21 15:58:31.536` (nearly 5 minutes later) that they are processed. 

We can see this trend happens across other accounts too. Here are a sample of some datadog queue times and we can see there are spikes all around the same time
![image](https://user-images.githubusercontent.com/1671796/175363708-fb2460b7-8939-4f30-ba0a-0b4416e999d4.png)
![image](https://user-images.githubusercontent.com/1671796/175363727-82a05782-923a-4075-96a1-cdef75826ed8.png)
![image](https://user-images.githubusercontent.com/1671796/175363744-bdab1c3a-4292-4b50-a354-87bb7c4128c2.png)

To fix this, I've used the `@queue` instance variable (that holds the queues passed into the worker), and used those to re-sort the queues after it's been rotated. So they will still rotate, but it will move the higher priority queues ahead before returning it. 
