### PR TITLE
DEVOPS-1528: Accurately report working state when JOBS_PER_FORK is enabled

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@ lib/bundler/man
 pkg
 rdoc
 spec/redis-server.log
+spec/redis.pid
+spec/*.rdb
 spec/reports
 test/tmp
 test/version_tmp

--- a/resque-round-robin.gemspec
+++ b/resque-round-robin.gemspec
@@ -10,6 +10,9 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "resque", "~> 1.19"
   gem.add_dependency "resque-dynamic-queues"
+  # Newer versions of redis-rb break many different things for us
+  # Test carefully when relaxing this restriction
+  gem.add_dependency "redis", "<= 4.5"
 
   gem.add_development_dependency('rspec', '~> 2.5')
   gem.add_development_dependency('rack-test', '~> 0.5.4')

--- a/spec/round-robin_spec.rb
+++ b/spec/round-robin_spec.rb
@@ -4,83 +4,105 @@ describe "RoundRobin" do
   before(:each) do
     Resque.redis.redis.flushall
 
+    stub_const("ENV", env)
+
     5.times { |i| Resque::Job.create(:r_1, SomeJob, index: i) }
     5.times { |i| Resque::Job.create(:q_1, SomeJob, index: i) }
     5.times { |i| Resque::Job.create(:q_2, SomeJob, index: i) }
-
-    stub_const("ENV", env)
   end
 
   let(:env) { { "QUEUES" => "q_*,r_*" } }
   let(:worker) { Resque::Worker.new }
 
-  context "with default job forking" do
-    it "switches queues, round robin" do
-      worker.process
-      Resque.size(:q_1).should == 5
-      Resque.size(:q_2).should == 4
-      Resque.size(:r_1).should == 5
-
-      worker.process
-      Resque.size(:q_1).should == 4
-      Resque.size(:q_2).should == 4
-      Resque.size(:r_1).should == 5
-
-      8.times do
+  describe "#process" do
+    context "with default job forking" do
+      it "switches queues, round robin" do
         worker.process
+        Resque.size(:q_1).should == 5
+        Resque.size(:q_2).should == 4
+        Resque.size(:r_1).should == 5
+
+        worker.process
+        Resque.size(:q_1).should == 4
+        Resque.size(:q_2).should == 4
+        Resque.size(:r_1).should == 5
+
+        8.times do
+          worker.process
+        end
+        Resque.size(:q_1).should == 0
+        Resque.size(:q_2).should == 0
+        Resque.size(:r_1).should == 5
+        worker.process
+        Resque.size(:r_1).should == 4
       end
-      Resque.size(:q_1).should == 0
-      Resque.size(:q_2).should == 0
-      Resque.size(:r_1).should == 5
-      worker.process
-      Resque.size(:r_1).should == 4
+    end
+
+    context "with multiple jobs per fork" do
+      let(:env) do
+        {
+          "QUEUES" => "q_*,r_*",
+          "JOBS_PER_FORK" => "4"
+        }
+      end
+
+      it "processes 4 jobs from each queue and then switches round robin" do
+        worker.process
+        expect(Resque.size(:q_2)).to eq(1)
+        expect(Resque.size(:q_1)).to eq(5)
+        expect(Resque.size(:r_1)).to eq(5)
+        expect(worker.job(true)).to be_empty
+
+        worker.process
+        expect(Resque.size(:q_2)).to eq(1)
+        expect(Resque.size(:q_1)).to eq(1)
+        expect(Resque.size(:r_1)).to eq(5)
+        expect(worker.job(true)).to be_empty
+
+        worker.process
+        expect(Resque.size(:q_2)).to eq(1)
+        expect(Resque.size(:q_1)).to eq(0)
+        expect(Resque.size(:r_1)).to eq(5)
+        expect(worker.job(true)).to be_empty
+
+        worker.process
+        expect(Resque.size(:q_2)).to eq(0)
+        expect(Resque.size(:q_1)).to eq(0)
+        expect(Resque.size(:r_1)).to eq(5)
+        expect(worker.job(true)).to be_empty
+
+        worker.process
+        expect(Resque.size(:q_2)).to eq(0)
+        expect(Resque.size(:q_1)).to eq(0)
+        expect(Resque.size(:r_1)).to eq(1)
+        expect(worker.job(true)).to be_empty
+      end
     end
   end
 
-  context "with multiple jobs per fork" do
-    before do
-      # There is code that depends on env vars being present when the plugin is
-      # included, so force a new include
-      Resque::Worker.send(:include, Resque::Plugins::RoundRobin)
-    end
-
+  describe "#perform_with_jobs_per_fork" do
     let(:env) do
       {
         "QUEUES" => "q_*,r_*",
         "JOBS_PER_FORK" => "4"
       }
     end
+    let(:job) { worker.reserve_with_round_robin }
 
-    it "switches queues round robin, processing 4 jobs at a time" do
-      worker.process
+    before { worker.perform_with_jobs_per_fork(job) }
+
+    it "reserves additional jobs from the same queue" do
       expect(Resque.size(:q_2)).to eq(1)
-      expect(Resque.size(:q_1)).to eq(5)
-      expect(Resque.size(:r_1)).to eq(5)
-      expect(worker.job(true)).to be_empty
+    end
 
-      worker.process
-      expect(Resque.size(:q_2)).to eq(1)
-      expect(Resque.size(:q_1)).to eq(1)
-      expect(Resque.size(:r_1)).to eq(5)
-      expect(worker.job(true)).to be_empty
-
-      worker.process
-      expect(Resque.size(:q_2)).to eq(1)
-      expect(Resque.size(:q_1)).to eq(0)
-      expect(Resque.size(:r_1)).to eq(5)
-      expect(worker.job(true)).to be_empty
-
-      worker.process
-      expect(Resque.size(:q_2)).to eq(0)
-      expect(Resque.size(:q_1)).to eq(0)
-      expect(Resque.size(:r_1)).to eq(5)
-      expect(worker.job(true)).to be_empty
-
-      worker.process
-      expect(Resque.size(:q_2)).to eq(0)
-      expect(Resque.size(:q_1)).to eq(0)
-      expect(Resque.size(:r_1)).to eq(1)
-      expect(worker.job(true)).to be_empty
+    it "updates working state in redis" do
+      expect(worker.job(:true)).to include(
+        "queue" => "q_2",
+        "payload" => {
+          "class" => "SomeJob",
+          "args"=>[{ "index"=>3 }]
+        }
+      )
     end
   end
 

--- a/spec/round-robin_spec.rb
+++ b/spec/round-robin_spec.rb
@@ -2,6 +2,9 @@ require "spec_helper"
 
 describe "RoundRobin" do
   before(:each) do
+    # Calling Resque.redis.redis looks weird, but it avoids a verbose
+    # warning at the beginning of each spec example, because the wrapper object
+    # returned by Resque.redis is namespaced, but the flushall command is not.
     Resque.redis.redis.flushall
 
     stub_const("ENV", env)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,8 @@
 require 'rspec'
+
+# This will force the gem to load with the jobs per fork logic enabled,
+# even though we are only executing one job at a time by default
+ENV["JOBS_PER_FORK"] = "1"
 require 'resque-round-robin'
 
 spec_dir = File.dirname(File.expand_path(__FILE__))
@@ -6,7 +10,7 @@ REDIS_CMD = "redis-server #{spec_dir}/redis-test.conf"
 
 puts "Starting redis for testing at localhost:9736..."
 puts `cd #{spec_dir}; #{REDIS_CMD}`
-Resque.redis = Redis.new(url: 'localhost:9736', inherit_socket: true)
+Resque.redis = 'localhost:9736'
 
 # Schedule the redis server for shutdown when tests are all finished.
 at_exit do
@@ -18,4 +22,3 @@ class SomeJob
   def self.perform(*args)
   end
 end
-

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,7 +6,7 @@ REDIS_CMD = "redis-server #{spec_dir}/redis-test.conf"
 
 puts "Starting redis for testing at localhost:9736..."
 puts `cd #{spec_dir}; #{REDIS_CMD}`
-Resque.redis = 'localhost:9736'
+Resque.redis = Redis.new(url: 'localhost:9736', inherit_socket: true)
 
 # Schedule the redis server for shutdown when tests are all finished.
 at_exit do


### PR DESCRIPTION
By default, resque workers fork a child process for each job they reserve from the queue. The parent process manages the worker's working state in redis by calling `working_on(job)` before forking, and `done_working` afterward. https://github.com/aha-app/resque/blob/0eac2a8a07be2d0693eeb354e8f2b60bfde80026/lib/resque/worker.rb#L244-L262

For specialized use cases, this gem supports conserving resources by allowing the forked child process to perform more than one job from the same queue (controlled by the `JOBS_PER_FORK` environment variable). The parent process only updates the working state for the first job, but the child fork continues to process more jobs from the same queue. With this PR, the child fork will now update the working state in redis for each successive job.

In order to get the tests running locally with a fresh Gemfile.lock, I had to pin the version of redis to <= 4.5. Newer versions introduced breaking changes related to the redis namespace gem and running multiple jobs per fork.